### PR TITLE
Modifications to compute_transects

### DIFF
--- a/ocean/transects/TransectAnalysis.ipynb
+++ b/ocean/transects/TransectAnalysis.ipynb
@@ -1,0 +1,276 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Populating the interactive namespace from numpy and matplotlib\n",
+      "mkdir: figures: File exists\r\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/pwolfram/miniconda2/lib/python2.7/site-packages/xarray/core/formatting.py:16: FutureWarning: The pandas.tslib module is deprecated and will be removed in a future version.\n",
+      "  from pandas.tslib import OutOfBoundsDatetime\n"
+     ]
+    }
+   ],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import matplotlib as mpl\n",
+    "import numpy as np\n",
+    "import xarray as xr\n",
+    "%pylab inline\n",
+    "rcParams['savefig.dpi'] = 150\n",
+    "plt.close('all')\n",
+    "%pwd\n",
+    "plotme= True\n",
+    "figuredir = './figures'\n",
+    "%mkdir figures\n",
+    "from tabulate import tabulate\n",
+    "def save_fig(name,dpi=300, *args, **kwargs):\n",
+    "        plt.savefig(figuredir+name,dpi=dpi, bbox_inches='tight')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "ds = xr.open_dataset('transport.nc')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<xarray.Dataset>\n",
+       "Dimensions:        (Time: 3720, nTransects: 15)\n",
+       "Coordinates:\n",
+       "  * Time           (Time) float64 0.04252 0.1233 0.2042 0.2877 0.3713 0.4549 ...\n",
+       "Dimensions without coordinates: nTransects\n",
+       "Data variables:\n",
+       "    TransectNames  (nTransects) |S64 'Drake Passage' 'Tasmania-Ant' ...\n",
+       "    Transport      (Time, nTransects) float64 146.8 162.7 152.9 -12.61 ..."
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ds"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<xarray.DataArray 'TransectNames' (nTransects: 15)>\n",
+       "array(['Drake Passage', 'Tasmania-Ant', 'Africa-Ant', 'Antilles Inflow',\n",
+       "       'Mona Passage', 'Windward Passage', 'Florida-Cuba', 'Florida-Bahamas',\n",
+       "       'Indonesian Throughflow', 'Agulhas', 'Mozambique Channel',\n",
+       "       'Bering Strait', 'Lancaster Sound', 'Fram Strait', 'Robeson Channel'],\n",
+       "      dtype='|S64')\n",
+       "Dimensions without coordinates: nTransects"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ds.TransectNames"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# filter out unneeded data\n",
+    "\n",
+    "# observations (Positive values are north and eastward, see Ringler et al 2013).  References from zotero shared \"observations\" folder in ACME Land Ice-Ocean Coupling papers\n",
+    "obs = {'Drake Passage': {'mean': 147.5 , 'std dev': 27.5, 'ref': '\\citep{donohue_mean_2016,nowlin_physics_1986}'}, \n",
+    "       'Tasmania-Ant': {'mean': 157, 'std dev': 10, 'ref': '\\citep{ganachaud_improved_2000,ganachaud_large-scale_2003}'},\n",
+    "       'Africa-Ant': {'mean': 150, 'std dev': 30, 'ref': 'Estimated from Drake and Tasmania-Ant passages from \\citep{ganachaud_improved_2000,ganachaud_large-scale_2003}'},\n",
+    "       'Indonesian Throughflow': {'mean': -15, 'std dev': 4, 'ref': '\\citep{sprintall_direct_2009}'},\n",
+    "       'Agulhas': {'mean': -70, 'std dev': 20, 'ref': '\\citep{bryden_role_2001}' },\n",
+    "       'Mozambique Channel': {'mean': -16, 'std dev': 13, 'ref': '\\citep{van_der_werf_comparison_2010}'},\n",
+    "       'Antilles Inflow': {'mean': -18.4, 'std dev': 4.7, 'ref': '\\citep{johns_atlantic_2002, roemmich_circulation_1981}'},\n",
+    "       'Mona Passage': {'mean': -2.6, 'std dev': 1.2, 'ref': '\\citep{johns_atlantic_2002, roemmich_circulation_1981}'},\n",
+    "       'Windward Passage': {'mean': 6.0, 'std dev': 3, 'ref': '\\citep{johns_atlantic_2002, roemmich_circulation_1981}'},\n",
+    "       'Florida-Cuba': {'mean': 31, 'std dev': 1.5, 'ref': '\\citep{johns_atlantic_2002, roemmich_circulation_1981}'},\n",
+    "       'Florida-Bahamas': {'mean': 31.5, 'std dev': 1.5, 'ref': '\\citep{johns_atlantic_2002, roemmich_circulation_1981}'},\n",
+    "       'Bering Strait': {'mean': 0.8, 'std dev': 0.3, 'ref': '\\citep{roach_direct_1995}'},\n",
+    "       'Lancaster Sound': {'mean': 0.8 , 'std dev': 0.3, 'ref': '\\citep{prinsenberg_monitoring_2005}'},\n",
+    "       'Fram Strait': {'mean': -3, 'std dev': 3, 'ref': '\\citep{schauer_arctic_2004}'},       \n",
+    "       'Robeson Channel': {'mean': -0.7 , 'std dev': .2 , 'ref': '\\citep{maltrud_eddy_2005}'}\n",
+    "       }"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Note: Africa-Ant completely estimated from a heuristic control volume analysis and could be removed from the table!\n",
+      "Transect location       EC60to30 (Sv)    RRS18to6 (Sv)    Observation (Sv)    Observation reference\n",
+      "----------------------  ---------------  ---------------  ------------------  --------------------------------------------------------------------------------------------------------------\n",
+      "Drake Passage           83.8 $\\pm$ 17.7  X $\\pm$ X        147.5 $\\pm$ 27.5    \\citep{donohue_mean_2016,nowlin_physics_1986}\n",
+      "Tasmania-Ant            98.0 $\\pm$ 20.0  X $\\pm$ X        157.0 $\\pm$ 10.0    \\citep{ganachaud_improved_2000,ganachaud_large-scale_2003}\n",
+      "Africa-Ant              83.4 $\\pm$ 17.9  X $\\pm$ X        150.0 $\\pm$ 30.0    Estimated from Drake and Tasmania-Ant passages from \\citep{ganachaud_improved_2000,ganachaud_large-scale_2003}\n",
+      "Antilles Inflow         -15.9 $\\pm$ 3.2  X $\\pm$ X        -18.4 $\\pm$ 4.7     \\citep{johns_atlantic_2002, roemmich_circulation_1981}\n",
+      "Mona Passage            -1.8 $\\pm$ 1.0   X $\\pm$ X        -2.6 $\\pm$ 1.2      \\citep{johns_atlantic_2002, roemmich_circulation_1981}\n",
+      "Windward Passage        1.9 $\\pm$ 2.1    X $\\pm$ X        6.0 $\\pm$ 3.0       \\citep{johns_atlantic_2002, roemmich_circulation_1981}\n",
+      "Florida-Cuba            15.7 $\\pm$ 1.6   X $\\pm$ X        31.0 $\\pm$ 1.5      \\citep{johns_atlantic_2002, roemmich_circulation_1981}\n",
+      "Florida-Bahamas         15.4 $\\pm$ 1.1   X $\\pm$ X        31.5 $\\pm$ 1.5      \\citep{johns_atlantic_2002, roemmich_circulation_1981}\n",
+      "Indonesian Throughflow  -11.0 $\\pm$ 3.6  X $\\pm$ X        -15.0 $\\pm$ 4.0     \\citep{sprintall_direct_2009}\n",
+      "Agulhas                 -68.5 $\\pm$ 5.8  X $\\pm$ X        -70.0 $\\pm$ 20.0    \\citep{bryden_role_2001}\n",
+      "Mozambique Channel      -18.7 $\\pm$ 6.8  X $\\pm$ X        -16.0 $\\pm$ 13.0    \\citep{van_der_werf_comparison_2010}\n",
+      "Bering Strait           0.9 $\\pm$ 0.5    X $\\pm$ X        0.8 $\\pm$ 0.3       \\citep{roach_direct_1995}\n",
+      "Lancaster Sound         0.5 $\\pm$ 0.3    X $\\pm$ X        0.8 $\\pm$ 0.3       \\citep{prinsenberg_monitoring_2005}\n",
+      "Fram Strait             -2.1 $\\pm$ 1.1   X $\\pm$ X        -3.0 $\\pm$ 3.0      \\citep{schauer_arctic_2004}\n",
+      "Robeson Channel         0.0 $\\pm$ 0.0    X $\\pm$ X        -0.7 $\\pm$ 0.2      \\citep{maltrud_eddy_2005}\n"
+     ]
+    }
+   ],
+   "source": [
+    "def check_in_range(amean, astddev, bmean, bstddev):\n",
+    "    amax = amean + astddev\n",
+    "    amin = amean - astddev\n",
+    "    bmax = bmean + bstddev\n",
+    "    bmin = bmean - bstddev\n",
+    "    \n",
+    "    inrange = ((amin < bmax) and (amin > bmin)) or ((amax < bmax) and (amax > bmin))\n",
+    "    return inrange\n",
+    "\n",
+    "# build the headers    \n",
+    "headers = []\n",
+    "headers.append('Transect location')\n",
+    "headers.append('EC60to30 (Sv)')\n",
+    "#headers.append('Result in range?')\n",
+    "headers.append('RRS18to6 (Sv)')\n",
+    "headers.append('Observation (Sv)')\n",
+    "headers.append('Observation reference')\n",
+    "#for atrans in ds.TransectNames:\n",
+    "#    headers.append(atrans.values)\n",
+    "    \n",
+    "table = []\n",
+    "# structure data into table format\n",
+    "for name, mean, stddev in zip(ds.TransectNames.values, ds.Transport.mean('Time').values, ds.Transport.std('Time').values):\n",
+    "    newrow = []\n",
+    "    newrow.append(str(name))\n",
+    "    newrow.append(u'%0.1f $\\pm$ %0.1f'%(mean, stddev))\n",
+    "    newrow.append(u'X $\\pm$ X')\n",
+    "    # observations\n",
+    "    obsmean = obs[str(name)]['mean']\n",
+    "    obsstd = obs[str(name)]['std dev']\n",
+    "    newrow.append(u'%0.1f $\\pm$ %0.1f'%(obsmean,obsstd))\n",
+    "    #newrow.append(str(check_in_range(mean, stddev, obsmean, obsstd)))\n",
+    "    newrow.append(str(obs[str(name)]['ref']))\n",
+    "    table.append(newrow)\n",
+    "\n",
+    "print 'Note: Africa-Ant completely estimated from a heuristic control volume analysis and could be removed from the table!'\n",
+    "print tabulate(table, headers=headers, floatfmt=\"0.1f\", numalign=\"center\") "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\\begin{tabular}{lllll}\n",
+      "\\toprule\n",
+      " Transect location      & EC60to30 (Sv)   & RRS18to6 (Sv)   & Observation (Sv)   & Observation reference                                                                                          \\\\\n",
+      "\\midrule\n",
+      " Drake Passage          & 83.8 $\\pm$ 17.7 & X $\\pm$ X       & 147.5 $\\pm$ 27.5   & \\citep{donohue_mean_2016,nowlin_physics_1986}                                                                  \\\\\n",
+      " Tasmania-Ant           & 98.0 $\\pm$ 20.0 & X $\\pm$ X       & 157.0 $\\pm$ 10.0   & \\citep{ganachaud_improved_2000,ganachaud_large-scale_2003}                                                     \\\\\n",
+      " Africa-Ant             & 83.4 $\\pm$ 17.9 & X $\\pm$ X       & 150.0 $\\pm$ 30.0   & Estimated from Drake and Tasmania-Ant passages from \\citep{ganachaud_improved_2000,ganachaud_large-scale_2003} \\\\\n",
+      " Antilles Inflow        & -15.9 $\\pm$ 3.2 & X $\\pm$ X       & -18.4 $\\pm$ 4.7    & \\citep{johns_atlantic_2002, roemmich_circulation_1981}                                                         \\\\\n",
+      " Mona Passage           & -1.8 $\\pm$ 1.0  & X $\\pm$ X       & -2.6 $\\pm$ 1.2     & \\citep{johns_atlantic_2002, roemmich_circulation_1981}                                                         \\\\\n",
+      " Windward Passage       & 1.9 $\\pm$ 2.1   & X $\\pm$ X       & 6.0 $\\pm$ 3.0      & \\citep{johns_atlantic_2002, roemmich_circulation_1981}                                                         \\\\\n",
+      " Florida-Cuba           & 15.7 $\\pm$ 1.6  & X $\\pm$ X       & 31.0 $\\pm$ 1.5     & \\citep{johns_atlantic_2002, roemmich_circulation_1981}                                                         \\\\\n",
+      " Florida-Bahamas        & 15.4 $\\pm$ 1.1  & X $\\pm$ X       & 31.5 $\\pm$ 1.5     & \\citep{johns_atlantic_2002, roemmich_circulation_1981}                                                         \\\\\n",
+      " Indonesian Throughflow & -11.0 $\\pm$ 3.6 & X $\\pm$ X       & -15.0 $\\pm$ 4.0    & \\citep{sprintall_direct_2009}                                                                                  \\\\\n",
+      " Agulhas                & -68.5 $\\pm$ 5.8 & X $\\pm$ X       & -70.0 $\\pm$ 20.0   & \\citep{bryden_role_2001}                                                                                       \\\\\n",
+      " Mozambique Channel     & -18.7 $\\pm$ 6.8 & X $\\pm$ X       & -16.0 $\\pm$ 13.0   & \\citep{van_der_werf_comparison_2010}                                                                           \\\\\n",
+      " Bering Strait          & 0.9 $\\pm$ 0.5   & X $\\pm$ X       & 0.8 $\\pm$ 0.3      & \\citep{roach_direct_1995}                                                                                      \\\\\n",
+      " Lancaster Sound        & 0.5 $\\pm$ 0.3   & X $\\pm$ X       & 0.8 $\\pm$ 0.3      & \\citep{prinsenberg_monitoring_2005}                                                                            \\\\\n",
+      " Fram Strait            & -2.1 $\\pm$ 1.1  & X $\\pm$ X       & -3.0 $\\pm$ 3.0     & \\citep{schauer_arctic_2004}                                                                                    \\\\\n",
+      " Robeson Channel        & 0.0 $\\pm$ 0.0   & X $\\pm$ X       & -0.7 $\\pm$ 0.2     & \\citep{maltrud_eddy_2005}                                                                                      \\\\\n",
+      "\\bottomrule\n",
+      "\\end{tabular}\n"
+     ]
+    }
+   ],
+   "source": [
+    "latextable = tabulate(table, headers=headers, floatfmt=\".2f\", numalign=\"center\", tablefmt=\"latex_booktabs\").replace('\\\\{','{').replace('\\\\}','}').replace('\\\\_','_').replace(u\"\\$\",u\"$\").replace(u\"\\\\textbackslash{}\",u\"\\\\\")\n",
+    "print latextable\n",
+    "with open('transportstable.tex','w') as f:\n",
+    "    f.write(latextable)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/ocean/transects/compute_transects.py
+++ b/ocean/transects/compute_transects.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """
 Name: compute_transects.py
-Author: Phillip J. Wolfram, Mark Petersen
+Author: Phillip J. Wolfram, Mark Petersen, Luke Van Roekel
 
 Computes transport through sections.
 

--- a/ocean/transects/compute_transects.py
+++ b/ocean/transects/compute_transects.py
@@ -9,7 +9,6 @@ Example call:
   ./compute_transects.py
   -k /lustre/scratch3/turquoise/mpeterse/runs/c62n/ocean/global_ocean/EC_60to30km/spin_up/init_step2/EC60to30v3_transect_masks.nc
   -m /lustre/scratch2/turquoise/mpeterse/runs/c69z/init.nc
-  -o '/lustre/scratch2/turquoise/mpeterse/runs/c69z/output/output.*.nc'
   -t '/lustre/scratch2/turquoise/mpeterse/runs/c69z/analysis_members/timeSeriesStatsMonthly.*.nc'
   -n 'Drake Passage'
 
@@ -21,6 +20,8 @@ mpl.use('Agg')
 import numpy as np
 import matplotlib.pyplot as plt
 import xarray as xr
+from netCDF4 import Dataset
+import glob
 
 m3ps_to_Sv = 1e-6 # m^3/sec flux to Sverdrups
 
@@ -31,41 +32,111 @@ def get_mask_short_names(mask):
   mask = mask.set_index(nTransects=['transectNames', 'shortNames'])
   return mask
 
-def compute_transport(output, timeavg, mesh, mask, name='Drake Passage'):
-  output = xr.open_mfdataset(output, concat_dim='Time', decode_times=False)
-  timeavg = xr.open_mfdataset(timeavg, concat_dim='Time', decode_times=False)
+def compute_transport(timeavg, mesh, mask, name='Drake Passage'):
   mesh = xr.open_dataset(mesh)
   mask = get_mask_short_names(xr.open_dataset(mask))
 
-  amask = mask.sel(shortNames=name).squeeze()
-  amask = amask.where(amask.transectEdgeGlobalIDs > 0, drop=True)
-  transectEdges = np.asarray(amask.transectEdgeGlobalIDs.values-1, dtype='i')
+  if name.lower() == 'all':
+    transectList = mask.shortNames[1:].values
+  else:
+    transectList = name.split(',')
 
-  edgesigns = mask.sel(nEdges=transectEdges, shortNames=name).squeeze().transectEdgeMaskSigns
-  dvEdge = mesh.dvEdge.sel(nEdges=transectEdges)
-  vel = timeavg.sel(nEdges=transectEdges).timeMonthly_avg_normalTransportVelocity
-  h = output.refLayerThickness.sel(Time=0).squeeze()
+  print 'Computing Transport for the following transects ',transectList
+  nTransects = len(transectList)
+  maxEdges = mask.dims['maxEdgesInTransect']
+# create empty t list for time
+  t = []
+# Compute refLayerThickness to avoid need for hist file
+  refBottom = mesh.refBottomDepth.values
+  nz = mesh.dims['nVertLevels']
+  h = np.zeros(nz)
+  h[0] = refBottom[0]
+  for i in range(1,nz):
+    h[i] = refBottom[i] - refBottom[i-1]
 
-  transport = (dvEdge*h*vel*edgesigns).sum(['nEdges','nVertLevels'])*m3ps_to_Sv
-  t = timeavg.timeMonthly_avg_daysSinceStartOfSim.values/365.
+# Get a list of edges and total edges in each transect
+  nEdgesInTransect = np.zeros(nTransects)
+  edgeVals = np.zeros((nTransects,maxEdges))
+  for i in range(nTransects):
+    amask = mask.sel(shortNames=transectList[i]).squeeze()
+    transectEdges = amask.transectEdgeGlobalIDs.values
+    inds = np.where(transectEdges > 0)[0]
+    nEdgesInTransect[i] = len(inds)
+    transectEdges = transectEdges[inds]
+    edgeVals[i,:len(inds)] = np.asarray(transectEdges-1, dtype='i')
 
-  plt.figure()
-  plt.plot(t, transport, 'k-', lw=3, label='monthly-averaged transport')
-  plt.gca().fill_between(t, (134.-14.)*np.ones_like(t), (134.+14.)*np.ones_like(t), alpha=0.3, label='observations')
-  plt.legend(loc='best', frameon=False)
-  plt.ylabel('Transport (Sv)')
-  plt.xlabel('yrs')
-  plt.title('Transport for ' + name)
-  plt.savefig('transport' + name.replace(' ', '') +'.png')
+  nEdgesInTransect = np.asarray(nEdgesInTransect, dtype='i')
+# Create a list with the start and stop for transect bounds
+  nTransectStartStop = np.zeros(nTransects+1)
+  for j in range(1,nTransects+1):
+    nTransectStartStop[j] = nTransectStartStop[j-1] + nEdgesInTransect[j-1]
 
+  edgesToRead = edgeVals[0,:nEdgesInTransect[0]]
+  for i in range(1,nTransects):
+    edgesToRead = np.hstack([edgesToRead,edgeVals[i,:nEdgesInTransect[i]]])
+
+  edgesToRead = np.asarray(edgesToRead, dtype='i')
+
+  dvEdge = mesh.dvEdge.sel(nEdges=edgesToRead).values
+
+  edgeSigns = np.zeros((nTransects,len(edgesToRead)))
+  for i in range(nTransects):
+    edgeSigns[i,:] = mask.sel(nEdges=edgesToRead, shortNames=transectList[i]).squeeze().transectEdgeMaskSigns.values
+
+# Read time average files one at a time and slice
+  fileList = sorted(glob.glob(timeavg))
+  transport = np.zeros((len(fileList),nTransects))
+  t = np.zeros(len(fileList))
+  for i,fname in enumerate(fileList):
+    ncid = Dataset(fname,'r')
+    vel = ncid.variables['timeMonthly_avg_normalTransportVelocity'][0,edgesToRead,:]
+    t[i] = ncid.variables['timeMonthly_avg_daysSinceStartOfSim'][:] / 365.
+    ncid.close()
+#   Compute transport for each transect
+    for j in range(nTransects):
+      start = int(nTransectStartStop[j])
+      stop = int(nTransectStartStop[j+1])
+      transport[i,j] = (dvEdge[start:stop,np.newaxis]*h[np.newaxis,:]*vel[start:stop,:] \
+          *edgeSigns[j,start:stop,np.newaxis]).sum()*m3ps_to_Sv
+
+    print fname
+ 
+  for j in range(nTransects):
+    plt.figure()
+    plt.plot(t, transport[:,j], 'k-', lw=3, label='monthly-averaged transport')
+    if transectList[j] == 'Drake Passage':
+      plt.gca().fill_between(t, (134.-14.)*np.ones_like(t), (134.+14.)*np.ones_like(t), alpha=0.3, label='observations')
+    plt.legend(loc='best', frameon=False)
+    plt.ylabel('Transport (Sv)')
+    plt.xlabel('yrs')
+    plt.title('Transport for ' + name)
+    plt.savefig('transport' + transectList[j].replace(' ', '') +'.png')
+
+# Add calls to save transport and then can build up
+  ncid=Dataset('transport.nc',mode='w',clobber=True, format='NETCDF3_CLASSIC')
+  ncid.createDimension('Time',None)
+  ncid.createDimension('nTransects',nTransects)
+  ncid.createDimension('StrLen',64)
+  transectNames=ncid.createVariable('TransectNames','c',('nTransects','StrLen'))
+  times=ncid.createVariable('Time','f8','Time')
+  transportOut=ncid.createVariable('Transport','f8',('Time','nTransects'))
+ 
+  times[:] = t
+  transportOut[:,:] = transport
+
+  for i in range(nTransects):
+    nLetters = len(transectList[i])
+    transectNames[i,:nLetters] = transectList[i]
+  ncid.close() 
+  
 
 if __name__ == "__main__":
   import argparse
   parser = argparse.ArgumentParser(description=__doc__,
                                    formatter_class=argparse.RawTextHelpFormatter)
-  parser.add_argument("-o", "--output_file_pattern", dest="output_filename_pattern",
-      help="MPAS Filename pattern for output.", metavar="FILE",
-      required=True)
+#  parser.add_argument("-o", "--output_file_pattern", dest="output_filename_pattern",
+#      help="MPAS Filename pattern for output.", metavar="FILE",
+#      required=True)
   parser.add_argument("-t", "--time_avg_file_pattern", dest="time_avg_filename_pattern",
       help="MPAS Filename pattern for time averaged AM output.", metavar="FILE",
       required=True)
@@ -77,6 +148,5 @@ if __name__ == "__main__":
       help="Transect name for computation", metavar="NAME")
   args = parser.parse_args()
 
-  compute_transport(output=args.output_filename_pattern,
-      timeavg=args.time_avg_filename_pattern,
+  compute_transport(timeavg=args.time_avg_filename_pattern,
       mesh=args.mesh_filename, mask=args.mask_filename, name=args.name)


### PR DESCRIPTION
This makes a number of modifications

1) removes mfdataset xarray call for netcdf4
2) no longer need a history file (not saved in E3SM now)
3) ability to plot multiple transects with string list
4) ability to plot all transects with -n 'all'
5) saves output to netcdf file for easy concat and no need to recompute
transport